### PR TITLE
Fix CP adjustment

### DIFF
--- a/character/models.py
+++ b/character/models.py
@@ -154,7 +154,10 @@ class Character(models.Model):
         if action not in ('inc', 'dec'):
             raise ValidationError("Action must be 'inc' or 'dec'")
         delta = 1 if action == 'inc' else -1
-        self.current_concentration += delta
+        self.current_concentration = max(
+            0,
+            min(self.current_concentration + delta, self.concentration)
+        )
         self.save(update_fields=['current_concentration'])
         return self.current_concentration
 


### PR DESCRIPTION
## Summary
- clamp concentration adjustment to stay within valid range

## Testing
- `python -m py_compile character/models.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: no tests)*
- `python manage.py check` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848826bdaa483208eaecc72e1da1d09