### PR TITLE
Add GM-controlled home storage for character inventories

### DIFF
--- a/character/admin.py
+++ b/character/admin.py
@@ -1,7 +1,7 @@
 # characters/admin.py
 
 from django.contrib import admin
-from .models import Character, InventoryItem, Equipment, CharacterClass, Talent
+from .models import Character, InventoryItem, Equipment, CharacterClass, Talent, HomeInventoryItem
 from unfold.admin import ModelAdmin, TabularInline, StackedInline
 
 
@@ -26,6 +26,15 @@ class InventoryItemInline(TabularInline):
     autocomplete_fields = ("item",)
 
 
+class HomeInventoryItemInline(TabularInline):
+    model = HomeInventoryItem
+    extra = 0
+    verbose_name = "Предмет в хранилище"
+    verbose_name_plural = "Домашнее хранилище"
+    fields = ("item", "quantity")
+    autocomplete_fields = ("item",)
+
+
 class EquipmentInline(StackedInline):
     model = Equipment
     extra = 0
@@ -41,7 +50,7 @@ class CharacterAdmin(ModelAdmin):
         "is_npc",
         "race", "gender",
         "str_stat", "dex_stat", "con_stat", "int_stat",
-        "carry_capacity", "max_weapon_weight", "max_armor_weight","can_trade"
+        "carry_capacity", "max_weapon_weight", "max_armor_weight", "can_trade", "home_storage_enabled"
     )
     list_display_links = ("name",)
     readonly_fields = (
@@ -49,13 +58,13 @@ class CharacterAdmin(ModelAdmin):
         "max_weapon_weight", "max_armor_weight",
     )
     list_filter = ("race", "gender", "world", "is_npc", "world",)
-    list_editable = ("can_trade",)
+    list_editable = ("can_trade", "home_storage_enabled")
     search_fields = ("name",)
     fieldsets = (
         (None, {
             "fields": ("owner", "world",
                        'image',
-                       "name", "gender", "race", "character_class", "character_talent", "is_alive", "can_trade")
+                       "name", "gender", "race", "character_class", "character_talent", "is_alive", "can_trade", "home_storage_enabled")
         }),
         ("RP-данные", {
             "fields": ("background", "notes"),
@@ -81,4 +90,4 @@ class CharacterAdmin(ModelAdmin):
         }),
 
     )
-    inlines = (InventoryItemInline, EquipmentInline)  # Управление инвентарём через отдельный раздел InventoryAdmin
+    inlines = (InventoryItemInline, HomeInventoryItemInline, EquipmentInline)  # Управление инвентарём через отдельный раздел InventoryAdmin

--- a/character/urls.py
+++ b/character/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 from .views import CharacterCreateView, CharacterDetailView, CharacterInventoryView, \
     UnequipSlotView, EquipItemView, DropItemView, LevelUpView, CharacterUpdateView, ChestDetailView, ToggleNpcFlagView, \
     AjaxAdjustHpView, AjaxAdjustCpView, AjaxAdjustTokenView, CharacterDeleteView, ClassListView, TalentListView, \
-    toggle_can_trade, CharacterGoldDeltaView
+    toggle_can_trade, CharacterGoldDeltaView, StoreItemInHomeView, RetrieveItemFromHomeView, ToggleHomeStorageView
 
 app_name = "characters"
 
@@ -18,6 +18,21 @@ urlpatterns = [
     path("characters/<int:character_id>/equip/<int:item_id>/", EquipItemView.as_view(), name="equip-item"),
     path("characters/<int:character_id>/unequip/<str:slot>/", UnequipSlotView.as_view(), name="unequip-slot"),
     path("characters/<int:character_id>/drop/<int:item_id>/", DropItemView.as_view(), name="drop-item"),
+    path(
+        "characters/<int:character_id>/storage/store/<int:item_id>/",
+        StoreItemInHomeView.as_view(),
+        name="home-storage-store",
+    ),
+    path(
+        "characters/<int:character_id>/storage/retrieve/<int:item_id>/",
+        RetrieveItemFromHomeView.as_view(),
+        name="home-storage-retrieve",
+    ),
+    path(
+        "characters/<int:character_id>/storage/toggle/",
+        ToggleHomeStorageView.as_view(),
+        name="home-storage-toggle",
+    ),
     path('level-up/<int:character_id>/', LevelUpView.as_view(), name='level-up'),
     path('chest/<int:instance_pk>/', ChestDetailView.as_view(), name='chest-detail'),
     path('npc-settings/<int:char_id>/', ToggleNpcFlagView.as_view(), name='toggle-npc-flag'),

--- a/templates/characters/inventory.html
+++ b/templates/characters/inventory.html
@@ -109,6 +109,13 @@
                                 {% csrf_token %}
                                 <button class="btn-inventory btn-drop">Выбросить</button>
                             </form>
+                            {% if can_use_home_storage %}
+                                <form class="storage-form" method="post"
+                                      action="{% url 'characters:home-storage-store' char.id entry.item.id %}">
+                                    {% csrf_token %}
+                                    <button class="btn-inventory btn-store">В хранилище</button>
+                                </form>
+                            {% endif %}
                         </td>
                     </tr>
                 {% empty %}
@@ -142,6 +149,70 @@
             </td>
         </tr>
     </template>
+    <div class="home-storage-controls">
+        {% if can_toggle_home_storage %}
+            <form method="post" action="{% url 'characters:home-storage-toggle' char.id %}">
+                {% csrf_token %}
+                {% if home_storage_enabled %}
+                    <button class="btn">Отключить домашнее хранилище</button>
+                {% else %}
+                    <button class="btn">Разрешить домашнее хранилище</button>
+                {% endif %}
+            </form>
+        {% endif %}
+    </div>
+
+    {% if home_storage_enabled %}
+        <div class="inventory-section home-storage">
+            <h2>Домашнее хранилище</h2>
+            {% if home_storage_items %}
+                <table class="item-table">
+                    <thead>
+                    <tr>
+                        <th>Название</th>
+                        <th>Кол-во</th>
+                        <th>Бонус</th>
+                        <th>Вес</th>
+                        <th>Легендарный баф</th>
+                        <th>Действия</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for entry in home_storage_items %}
+                        <tr>
+                            <td class="name-cell"><span
+                                    style="border-left: 6px solid {{ entry.item.rarity.color }}; padding-left: 6px">{{ entry.item.name }}</span>
+                            </td>
+                            <td class="quantity-cell">{{ entry.quantity }}</td>
+                            <td class="bonus-cell">+{{ entry.item.bonus }}</td>
+                            <td class="weight-cell">{{ entry.item.weight }} кг</td>
+                            <td class="legendary-cell">
+                                {% if entry.item.legendary_buff %}{{ entry.item.legendary_buff }}{% else %}—{% endif %}
+                            </td>
+                            <td class="td-buttons">
+                                {% if can_use_home_storage %}
+                                    <form class="storage-form" method="post"
+                                          action="{% url 'characters:home-storage-retrieve' char.id entry.item.id %}">
+                                        {% csrf_token %}
+                                        <button class="btn-inventory btn-store">Забрать</button>
+                                    </form>
+                                {% else %}
+                                    <span class="text-muted">Недоступно</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            {% else %}
+                <p>Хранилище пусто.</p>
+            {% endif %}
+        </div>
+    {% else %}
+        {% if can_toggle_home_storage %}
+            <p class="text-muted">Домашнее хранилище сейчас отключено.</p>
+        {% endif %}
+    {% endif %}
     <h2>Сундуки</h2>
     {% if char.chests.exists %}
         {% for chest in char.chests.all %}


### PR DESCRIPTION
## Summary
- add a GM-toggleable `home_storage_enabled` flag and a dedicated `HomeInventoryItem` model for characters
- expose home storage management in the admin and character inventory UI with controls to move items in and out
- add views and routes so GMs can enable storage and players can deposit or withdraw items when permitted

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68fe674107dc83209ee43508133f3dfa