### PR TITLE
Customize admin dashboard with Unfold widgets

### DIFF
--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from typing import Any, Dict, List
+
+from django.contrib import admin
+from django.db.models import Count
+from django.db.models.functions import TruncWeek
+from django.template.response import TemplateResponse
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.formats import date_format
+from django.utils.translation import gettext_lazy as _
+
+from accounts.models import User
+from character.models import Character
+from items.models import Item
+from magic.models import Spell
+from worlds.models import World, WorldInvitation
+
+
+def _build_character_growth() -> tuple[str, str]:
+    """Return chart labels/data for characters created during the last six weeks."""
+    now = timezone.now()
+    start_period = now - timedelta(weeks=5)
+
+    aggregated = (
+        Character.objects.filter(created_at__gte=start_period)
+        .annotate(period=TruncWeek("created_at"))
+        .values("period")
+        .annotate(total=Count("id"))
+    )
+
+    counts: Dict[Any, int] = {}
+    for entry in aggregated:
+        period = entry.get("period")
+        if period is None:
+            continue
+        period_start = timezone.localtime(period).date()
+        counts[period_start] = entry.get("total", 0)
+
+    labels: List[str] = []
+    values: List[int] = []
+    for offset in range(5, -1, -1):
+        reference = now - timedelta(weeks=offset)
+        reference = reference - timedelta(days=reference.weekday())
+        period_key = reference.date()
+        labels.append(date_format(reference, "d E"))
+        values.append(counts.get(period_key, 0))
+
+    chart_data = {
+        "labels": labels,
+        "datasets": [
+            {
+                "label": str(_("Новые персонажи")),
+                "data": values,
+                "borderColor": "#6366F1",
+                "backgroundColor": "rgba(99, 102, 241, 0.2)",
+                "pointRadius": 4,
+                "pointHoverRadius": 6,
+                "tension": 0.35,
+                "fill": True,
+            }
+        ],
+    }
+
+    chart_options = {
+        "responsive": True,
+        "maintainAspectRatio": False,
+        "plugins": {
+            "legend": {"display": False},
+            "tooltip": {
+                "backgroundColor": "rgba(17, 24, 39, 0.85)",
+                "displayColors": False,
+            },
+        },
+        "scales": {
+            "x": {
+                "grid": {"display": False},
+                "ticks": {"color": "#6B7280"},
+            },
+            "y": {
+                "grid": {"color": "rgba(209, 213, 219, 0.4)"},
+                "ticks": {
+                    "precision": 0,
+                    "color": "#6B7280",
+                },
+            },
+        },
+    }
+
+    return json.dumps(chart_data), json.dumps(chart_options)
+
+
+def _build_stats() -> List[Dict[str, Any]]:
+    total_users = User.objects.count()
+    active_users = User.objects.filter(is_active=True).count()
+
+    total_characters = Character.objects.count()
+    new_characters_week = Character.objects.filter(
+        created_at__gte=timezone.now() - timedelta(days=7)
+    ).count()
+
+    total_worlds = World.objects.count()
+    pending_invitations = WorldInvitation.objects.filter(accepted=False).count()
+
+    total_items = Item.objects.count()
+    new_items_week = Item.objects.filter(
+        created_at__gte=timezone.now() - timedelta(days=7)
+    ).count()
+
+    return [
+        {
+            "label": _("Пользователи"),
+            "value": total_users,
+            "icon": "groups",
+            "caption": _("активных: %(count)s") % {"count": active_users},
+        },
+        {
+            "label": _("Персонажи"),
+            "value": total_characters,
+            "icon": "stadia_controller",
+            "caption": _("новых за неделю: %(count)s") % {"count": new_characters_week},
+        },
+        {
+            "label": _("Миры"),
+            "value": total_worlds,
+            "icon": "public",
+            "caption": _("приглашений в ожидании: %(count)s")
+            % {"count": pending_invitations},
+        },
+        {
+            "label": _("Предметы"),
+            "value": total_items,
+            "icon": "inventory_2",
+            "caption": _("новых за неделю: %(count)s") % {"count": new_items_week},
+        },
+    ]
+
+
+def _build_worlds() -> List[World]:
+    return list(
+        World.objects.annotate(
+            player_count=Count("players", distinct=True),
+            character_count=Count("characters", distinct=True),
+        )
+        .order_by("-created_at")[:5]
+    )
+
+
+def _build_quick_links() -> List[Dict[str, str]]:
+    return [
+        {
+            "title": _("Создать персонажа"),
+            "description": _("Быстрый переход к форме добавления нового героя."),
+            "icon": "face_retouching_natural",
+            "url": reverse("admin:character_character_add"),
+        },
+        {
+            "title": _("Добавить заклинание"),
+            "description": _("Пополните базу свежей магией в один клик."),
+            "icon": "auto_awesome",
+            "url": reverse("admin:magic_spell_add"),
+        },
+        {
+            "title": _("Создать предмет"),
+            "description": _("Добавьте артефакт или экипировку прямо сейчас."),
+            "icon": "shield_with_heart",
+            "url": reverse("admin:items_item_add"),
+        },
+        {
+            "title": _("Открыть новый мир"),
+            "description": _("Подготовьте площадку для следующей кампании."),
+            "icon": "travel_explore",
+            "url": reverse("admin:worlds_world_add"),
+        },
+    ]
+
+
+def build_dashboard_context() -> Dict[str, Any]:
+    chart_data, chart_options = _build_character_growth()
+
+    return {
+        "dashboard_stats": _build_stats(),
+        "character_growth_data": chart_data,
+        "character_growth_options": chart_options,
+        "dashboard_worlds": _build_worlds(),
+        "latest_spells": Spell.objects.select_related("school", "category")
+        .order_by("-id")[:5],
+        "latest_items": Item.objects.select_related("rarity", "type")
+        .order_by("-created_at")[:5],
+        "quick_links": _build_quick_links(),
+    }
+
+
+def _custom_admin_index(self, request, extra_context: Dict[str, Any] | None = None):
+    extra_context = extra_context or {}
+    extra_context.update(build_dashboard_context())
+
+    response: TemplateResponse = _ORIGINAL_INDEX(request, extra_context=extra_context)
+    return response
+
+
+_ORIGINAL_INDEX = admin.site.index
+admin.site.index = _custom_admin_index.__get__(admin.site, admin.sites.AdminSite)
+admin.site.index_template = "admin/index.html"

--- a/core/urls.py
+++ b/core/urls.py
@@ -20,6 +20,8 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.views.generic import TemplateView
 
+from core import admin_dashboard  # noqa: F401
+
 from character.views import (
     StoreItemInHomeView,
     RetrieveItemFromHomeView,

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,0 +1,132 @@
+{% extends 'admin/base.html' %}
+{% load i18n unfold %}
+
+{% block breadcrumbs %}{% endblock %}
+
+{% block title %}{% if subtitle %}{{ subtitle }} | {% endif %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block branding %}
+    {% include "unfold/helpers/site_branding.html" %}
+{% endblock %}
+
+{% block content %}
+    <div class="flex flex-col gap-8">
+        <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            {% for stat in dashboard_stats %}
+                {% component "unfold/components/card.html" with class="relative overflow-hidden" %}
+                    <div class="flex items-center gap-4">
+                        <div class="flex h-12 w-12 items-center justify-center rounded-full bg-primary-50 text-primary-600 dark:bg-primary-500/10 dark:text-primary-300">
+                            <span class="material-symbols-outlined text-3xl">{{ stat.icon }}</span>
+                        </div>
+                        <div class="min-w-0">
+                            <p class="text-xs font-semibold uppercase tracking-wide text-base-400 dark:text-base-500">{{ stat.label }}</p>
+                            <p class="text-2xl font-semibold text-font-important-light dark:text-font-important-dark">{{ stat.value }}</p>
+                        </div>
+                    </div>
+                    {% if stat.caption %}
+                        <p class="mt-4 text-sm text-base-500 dark:text-base-400">{{ stat.caption }}</p>
+                    {% endif %}
+                {% endcomponent %}
+            {% endfor %}
+        </div>
+
+        <div class="grid gap-6 lg:grid-cols-3">
+            <div class="lg:col-span-2">
+                {% component "unfold/components/card.html" with title=_("Динамика персонажей") %}
+                    <p class="mb-4 text-sm text-base-500 dark:text-base-400">{% trans "Отслеживайте, сколько новых персонажей появляется каждую неделю за последние полтора месяца." %}</p>
+                    {% component "unfold/components/chart/line.html" with data=character_growth_data options=character_growth_options height=260 %}{% endcomponent %}
+                {% endcomponent %}
+            </div>
+            <div>
+                {% component "unfold/components/card.html" with title=_("Быстрые действия") %}
+                    <ul class="space-y-4">
+                        {% for link in quick_links %}
+                            <li>
+                                <a href="{{ link.url }}" class="flex items-start gap-3 rounded-default border border-base-200 px-4 py-3 transition hover:border-primary-400 hover:bg-primary-50/60 hover:text-primary-600 dark:border-base-700 dark:hover:border-primary-500/70 dark:hover:bg-primary-500/10 dark:hover:text-primary-300">
+                                    <span class="material-symbols-outlined text-2xl">{{ link.icon }}</span>
+                                    <span class="flex min-w-0 flex-col">
+                                        <span class="font-semibold text-font-important-light dark:text-font-important-dark">{{ link.title }}</span>
+                                        <span class="text-sm text-base-500 dark:text-base-400">{{ link.description }}</span>
+                                    </span>
+                                    <span class="material-symbols-outlined ml-auto text-base-400 dark:text-base-600">arrow_outward</span>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endcomponent %}
+            </div>
+        </div>
+
+        <div class="grid gap-6 xl:grid-cols-3">
+            <div class="space-y-6">
+                {% component "unfold/components/card.html" with title=_("Активные миры") %}
+                    <div class="space-y-4">
+                        {% for world in dashboard_worlds %}
+                            <div class="flex items-start gap-3 rounded-default border border-dashed border-base-200 p-3 dark:border-base-700">
+                                <div class="flex h-10 w-10 items-center justify-center rounded-full bg-secondary-50 text-secondary-600 dark:bg-secondary-500/10 dark:text-secondary-300">
+                                    <span class="material-symbols-outlined">public</span>
+                                </div>
+                                <div class="min-w-0 flex-1">
+                                    <p class="font-semibold text-font-important-light dark:text-font-important-dark">{{ world.name }}</p>
+                                    <p class="text-xs uppercase tracking-wide text-base-400 dark:text-base-500">{{ world.created_at|date:"d E Y" }}</p>
+                                </div>
+                                <div class="flex flex-col items-end gap-2 text-sm text-base-500 dark:text-base-400">
+                                    <span class="flex items-center gap-1"><span class="material-symbols-outlined md-18 text-primary-500 dark:text-primary-300">groups</span>{{ world.player_count }}</span>
+                                    <span class="flex items-center gap-1"><span class="material-symbols-outlined md-18 text-secondary-500 dark:text-secondary-300">stadia_controller</span>{{ world.character_count }}</span>
+                                </div>
+                            </div>
+                        {% empty %}
+                            <p class="text-sm text-base-500 dark:text-base-400">{% trans "Пока не создано ни одного мира." %}</p>
+                        {% endfor %}
+                    </div>
+                {% endcomponent %}
+            </div>
+            <div class="space-y-6">
+                {% component "unfold/components/card.html" with title=_("Последние заклинания") %}
+                    <ul class="space-y-3">
+                        {% for spell in latest_spells %}
+                            <li class="flex items-start gap-3 rounded-default border border-base-200 p-3 dark:border-base-700">
+                                <span class="material-symbols-outlined text-primary-500 dark:text-primary-300">auto_awesome</span>
+                                <div class="min-w-0">
+                                    <p class="font-semibold text-font-important-light dark:text-font-important-dark">{{ spell.name }}</p>
+                                    <p class="text-sm text-base-500 dark:text-base-400">{{ spell.school.name }} · {{ spell.category.name }} · {% blocktrans with level=spell.level %}уровень {{ level }}{% endblocktrans %}</p>
+                                </div>
+                            </li>
+                        {% empty %}
+                            <p class="text-sm text-base-500 dark:text-base-400">{% trans "Добавьте первое заклинание, чтобы увидеть его здесь." %}</p>
+                        {% endfor %}
+                    </ul>
+                {% endcomponent %}
+            </div>
+            <div class="space-y-6">
+                {% component "unfold/components/card.html" with title=_("Новые предметы") %}
+                    <ul class="space-y-3">
+                        {% for item in latest_items %}
+                            <li class="flex items-start gap-3 rounded-default border border-base-200 p-3 dark:border-base-700">
+                                <span class="material-symbols-outlined text-amber-500">inventory_2</span>
+                                <div class="min-w-0">
+                                    <p class="font-semibold text-font-important-light dark:text-font-important-dark">{{ item.name }}</p>
+                                    <p class="text-sm text-base-500 dark:text-base-400">{{ item.type.name }} · {{ item.rarity.name }} · {{ item.created_at|date:"d E Y" }}</p>
+                                </div>
+                            </li>
+                        {% empty %}
+                            <p class="text-sm text-base-500 dark:text-base-400">{% trans "Предметы ещё не созданы." %}</p>
+                        {% endfor %}
+                    </ul>
+                {% endcomponent %}
+            </div>
+        </div>
+
+        <div class="grid gap-6 xl:grid-cols-[2fr_minmax(0,1fr)]">
+            <div class="bg-white border border-base-200 overflow-hidden rounded-default shadow-xs dark:border-base-800 dark:bg-base-900">
+                <h2 class="border-b border-base-200 bg-base-50 px-6 py-4 text-lg font-semibold text-font-important-light dark:border-base-800 dark:bg-white/[.02] dark:text-font-important-dark">{% trans "Управление контентом" %}</h2>
+                <div class="px-6 py-4">
+                    {% include "unfold/helpers/app_list_default.html" %}
+                </div>
+            </div>
+            <div>
+                {% include "unfold/helpers/history.html" %}
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- introduce a custom admin dashboard template that displays statistics, quick actions, and recent content with Unfold styling
- add an admin dashboard context builder that provides chart data, quick links, and world/activity summaries for the index view

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68fe79bcb8dc8320983bee95952c820d