### PR TITLE
Adjust related articles sidebar positioning

### DIFF
--- a/templates/rulebook/article_detail.html
+++ b/templates/rulebook/article_detail.html
@@ -7,6 +7,10 @@
 {% block css %}
     <link rel="stylesheet" href="{% static 'css/md_style.css' %}">
     <style>
+        :root {
+            --header-height: 72px;
+        }
+
         .article-page {
             max-width: 1200px;
             margin: 2rem auto;
@@ -15,19 +19,21 @@
 
         .article-layout {
             display: grid;
-            grid-template-columns: 280px 1fr;
+            grid-template-columns: 1fr 280px;
             gap: 1.5rem;
             align-items: start;
+            grid-template-areas: "main sidebar";
         }
 
         .related-sidebar {
+            grid-area: sidebar;
             background: #f8f3eb;
             border: 1px solid #e0d6c2;
             border-radius: 12px;
             padding: 1rem 1.25rem;
             box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
             position: sticky;
-            top: 1.5rem;
+            top: calc(var(--header-height) + 1rem);
         }
 
         .related-header {
@@ -81,6 +87,7 @@
         }
 
         .article-main {
+            grid-area: main;
             background: #fff;
             border: 1px solid #e0d6c2;
             border-radius: 12px;
@@ -182,7 +189,7 @@
 
         @media (max-width: 1100px) {
             .article-layout {
-                grid-template-columns: 240px 1fr;
+                grid-template-columns: 1fr 240px;
             }
         }
 
@@ -193,6 +200,9 @@
 
             .article-layout {
                 grid-template-columns: 1fr;
+                grid-template-areas:
+                    "main"
+                    "sidebar";
             }
 
             .article-main {
@@ -206,11 +216,12 @@
             .related-sidebar {
                 display: none;
                 position: fixed;
-                inset: 0;
+                top: var(--header-height);
+                inset-inline-start: 0;
                 right: auto;
                 width: 82%;
                 max-width: 320px;
-                height: 100%;
+                height: calc(100% - var(--header-height));
                 overflow-y: auto;
                 z-index: 20;
                 border-radius: 0 16px 16px 0;
@@ -223,6 +234,8 @@
 
             .sidebar-overlay.is-visible {
                 display: block;
+                top: var(--header-height);
+                height: calc(100% - var(--header-height));
             }
 
             .sidebar-toggle {


### PR DESCRIPTION
## Summary
- move the related articles sidebar to the right column of the article layout
- add layout grid areas and sticky offsets so the sidebar accounts for the header height
- update mobile sidebar/overlay positioning to avoid header overlap while keeping the drawer behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69581b4bffe0832094c035e161ee05b5)